### PR TITLE
Add posix-compliant tar for gh builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
   make \
   openssh-client \
   python2 \
+  tar \
   # Below are for packages such as https://www.npmjs.com/package/imagemin
   autoconf \
   automake \


### PR DESCRIPTION
Busybox tar is not able to create posix format tar files. This causes cache actions in github actions to fail.