### PR TITLE
Feat: dev builds segregation with chromium package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,21 @@ VERSION_TAG=v2-latest
 build:
 	$(eval IMAGE=${REGISTRY}:${NODE_VERSION}-${VERSION_TAG})
 	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} -t ${IMAGE}-${ARCH} .
+	# build dev images
+	$(eval IMAGE=${REGISTRY}:dev-${NODE_VERSION}-${VERSION_TAG})
+	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} -t ${IMAGE}-${ARCH} dev
 
 push:
 	$(eval IMAGE=${REGISTRY}:${NODE_VERSION}-${VERSION_TAG})
 	docker push ${IMAGE}-${ARCH}
+	$(eval IMAGE=${REGISTRY}:dev-${NODE_VERSION}-${VERSION_TAG})
+	docker push ${IMAGE}-${ARCH}
 
 manifest:
 	$(eval IMAGE=${REGISTRY}:${NODE_VERSION}-${VERSION_TAG})
+	docker manifest create ${IMAGE} --amend ${IMAGE}-arm64 --amend ${IMAGE}-amd64
+	docker manifest push ${IMAGE}
+	$(eval IMAGE=${REGISTRY}:dev-${NODE_VERSION}-${VERSION_TAG})
 	docker manifest create ${IMAGE} --amend ${IMAGE}-arm64 --amend ${IMAGE}-amd64
 	docker manifest push ${IMAGE}
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build:
 	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} -t ${IMAGE}-${ARCH} .
 	# build dev images
 	$(eval IMAGE=${REGISTRY}:dev-${NODE_VERSION}-${VERSION_TAG})
-	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} -t ${IMAGE}-${ARCH} dev
+	docker build --build-arg ALPINE_VERSION=${ALPINE_VERSION} --build-arg NODE_VERSION=${NODE_VERSION} --build-arg VERSION_TAG=${VERSION_TAG} -t ${IMAGE}-${ARCH} dev
 
 push:
 	$(eval IMAGE=${REGISTRY}:${NODE_VERSION}-${VERSION_TAG})

--- a/README.md
+++ b/README.md
@@ -15,15 +15,21 @@ This image suite provides 2 streams for images:
 **Latest**
 
 ```
-docker.io/skpr/node:14-v2-latest
-docker.io/skpr/node:16-v2-latest
-docker.io/skpr/node:18-v2-latest
+docker.io/skpr/node:14-v2-latest-amd64
+docker.io/skpr/node:16-v2-latest-amd64
+docker.io/skpr/node:18-v2-latest-amd64
+docker.io/skpr/node:dev-14-v2-latest-amd64
+docker.io/skpr/node:dev-16-v2-latest-amd64
+docker.io/skpr/node:dev-18-v2-latest-amd64
 ```
 
 **Edge**
 
 ```
-docker.io/skpr/node:14-v2-edge
-docker.io/skpr/node:16-v2-edge
-docker.io/skpr/node:18-v2-edge
+docker.io/skpr/node:14-v2-edge-amd64
+docker.io/skpr/node:16-v2-edge-amd64
+docker.io/skpr/node:18-v2-edge-amd64
+docker.io/skpr/node:dev-14-v2-edge-amd64
+docker.io/skpr/node:dev-16-v2-edge-amd64
+docker.io/skpr/node:dev-18-v2-edge-amd64
 ```

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ This image suite provides 2 streams for images:
 **Latest**
 
 ```
-docker.io/skpr/node:14-v2-latest-amd64
-docker.io/skpr/node:16-v2-latest-amd64
-docker.io/skpr/node:18-v2-latest-amd64
-docker.io/skpr/node:dev-14-v2-latest-amd64
-docker.io/skpr/node:dev-16-v2-latest-amd64
-docker.io/skpr/node:dev-18-v2-latest-amd64
+docker.io/skpr/node:14-v2-latest
+docker.io/skpr/node:16-v2-latest
+docker.io/skpr/node:18-v2-latest
+docker.io/skpr/node:dev-14-v2-latest
+docker.io/skpr/node:dev-16-v2-latest
+docker.io/skpr/node:dev-18-v2-latest
 ```
 
 **Edge**
 
 ```
-docker.io/skpr/node:14-v2-edge-amd64
-docker.io/skpr/node:16-v2-edge-amd64
-docker.io/skpr/node:18-v2-edge-amd64
-docker.io/skpr/node:dev-14-v2-edge-amd64
-docker.io/skpr/node:dev-16-v2-edge-amd64
-docker.io/skpr/node:dev-18-v2-edge-amd64
+docker.io/skpr/node:14-v2-edge
+docker.io/skpr/node:16-v2-edge
+docker.io/skpr/node:18-v2-edge
+docker.io/skpr/node:dev-14-v2-edge
+docker.io/skpr/node:dev-16-v2-edge
+docker.io/skpr/node:dev-18-v2-edge
 ```

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,6 +1,7 @@
 ARG NODE_VERSION=16
 ARG ALPINE_VERSION=3.18
-FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
+ARG VERSION_TAG=v2-latest
+FROM docker.io/skpr/node:${NODE_VERSION}-${VERSION_TAG}
 
 RUN apk add --no-cache \
   bash \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,0 +1,33 @@
+ARG NODE_VERSION=16
+ARG ALPINE_VERSION=3.18
+FROM node:${NODE_VERSION}-alpine${ALPINE_VERSION}
+
+RUN apk add --no-cache \
+  bash \
+  ca-certificates \
+  g++ \
+  git \
+  make \
+  openssh-client \
+  python2 \
+  tar \
+  # Below are for packages such as https://www.npmjs.com/package/imagemin
+  autoconf \
+  automake \
+  libpng-dev \
+  libtool \
+  nasm \
+  util-linux \
+  vips-dev \
+  chromium
+
+
+RUN deluser node
+RUN adduser -D -u 1000 skpr
+RUN mkdir /data && chown skpr:skpr /data
+
+WORKDIR /data
+
+USER skpr
+
+ENV PATH /data/node_modules/.bin:$PATH

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -3,32 +3,10 @@ ARG ALPINE_VERSION=3.18
 ARG VERSION_TAG=v2-latest
 FROM docker.io/skpr/node:${NODE_VERSION}-v2-latest
 
+USER root
 RUN apk add --no-cache \
-  bash \
-  ca-certificates \
-  g++ \
-  git \
-  make \
-  openssh-client \
-  python2 \
-  tar \
-  # Below are for packages such as https://www.npmjs.com/package/imagemin
-  autoconf \
-  automake \
-  libpng-dev \
-  libtool \
-  nasm \
-  util-linux \
-  vips-dev \
   chromium
-
-
-RUN deluser node
-RUN adduser -D -u 1000 skpr
-RUN mkdir /data && chown skpr:skpr /data
 
 WORKDIR /data
 
 USER skpr
-
-ENV PATH /data/node_modules/.bin:$PATH

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=16
 ARG ALPINE_VERSION=3.18
 ARG VERSION_TAG=v2-latest
-FROM docker.io/skpr/node:${NODE_VERSION}-${VERSION_TAG}
+FROM docker.io/skpr/node:${NODE_VERSION}-v2-latest
 
 RUN apk add --no-cache \
   bash \


### PR DESCRIPTION
### **Overview:** 
We should be able to have a Node image for Dev use cases with dev tools on it as extras. 

### **Solution:**
Create a separate Dockerfile for dev images with additional dev tools on it. For now it's only chromium but we can add more as we go. The Makefile has also been updated so that the build / push steps can accommodate the new dev Images. 