### PR TITLE
Bump to Alpine 3.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ platforms: &platforms
   - arm64
 
 node_versions: &node_versions
-  - "14"
   - "16"
   - "18"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
   git \
   make \
   openssh-client \
-  python2 \
+  python3 \
   tar \
   # Below are for packages such as https://www.npmjs.com/package/imagemin
   autoconf \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 REGISTRY=skpr/node
-ALPINE_VERSION=3.15
+ALPINE_VERSION=3.18
 NODE_VERSION=16
 ARCH=amd64
 VERSION_TAG=v2-latest

--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ This image suite provides 2 streams for images:
 **Latest**
 
 ```
-docker.io/skpr/node:14-v2-latest
 docker.io/skpr/node:16-v2-latest
 docker.io/skpr/node:18-v2-latest
-docker.io/skpr/node:dev-14-v2-latest
 docker.io/skpr/node:dev-16-v2-latest
 docker.io/skpr/node:dev-18-v2-latest
 ```
@@ -26,10 +24,8 @@ docker.io/skpr/node:dev-18-v2-latest
 **Edge**
 
 ```
-docker.io/skpr/node:14-v2-edge
 docker.io/skpr/node:16-v2-edge
 docker.io/skpr/node:18-v2-edge
-docker.io/skpr/node:dev-14-v2-edge
 docker.io/skpr/node:dev-16-v2-edge
 docker.io/skpr/node:dev-18-v2-edge
 ```


### PR DESCRIPTION
**Changes**

* Bump to Alpine 3.18
* Remove Node 14 (Not supported in upstream https://hub.docker.com/_/node)