### PR TITLE
Set UV_USE_TO_URING to 0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 ARG FROM_IMAGE
 FROM ${FROM_IMAGE}
 
+# Libuv 1.45.0 is affected by a kernel bug on certain kernels.
+# This leads to errors where Garden tool downloading errors with ETXTBSY
+# Apparently file descriptor accounting is broken when using USE_IO_URING
+# on older kernels
+# See also: https://github.com/libuv/libuv/pull/4141/files
+# TODO: Remove this once libuv 1.47 landed in a future NodeJS version, and we upgraded to it.
+ENV UV_USE_IO_URING=0
+
 RUN apk add --no-cache \
   bash \
   ca-certificates \


### PR DESCRIPTION
On older kernels there's a bug in libuv...

It wasn't needed locally so I suspect this might be something CircleCI will need to patch on infra.