### PR TITLE
To Releases (May Maintenance Window)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ node_versions: &node_versions
   - "16"
   - "18"
   - "20"
-  - "21"
 
 workflows:
   build_test:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This image suite provides 2 streams for images:
 docker.io/skpr/node:14-v2-latest (Depreciated. Will not receive updates.)
 docker.io/skpr/node:16-v2-latest
 docker.io/skpr/node:18-v2-latest
+docker.io/skpr/node:20-v2-latest
 docker.io/skpr/node:dev-16-v2-latest
 docker.io/skpr/node:dev-18-v2-latest
 docker.io/skpr/node:dev-20-v2-latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ docker.io/skpr/node:16-v2-latest
 docker.io/skpr/node:18-v2-latest
 docker.io/skpr/node:dev-16-v2-latest
 docker.io/skpr/node:dev-18-v2-latest
+docker.io/skpr/node:dev-20-v2-latest
 ```
 
 **Edge**

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This image suite provides 2 streams for images:
 **Latest**
 
 ```
-docker.io/skpr/node:14-v2-latest (Depreciated. Will not receive updates.)
-docker.io/skpr/node:16-v2-latest (Depreciated. Will not receive updates.)
+docker.io/skpr/node:14-v2-latest (Unsupported. Will not receive updates.)
+docker.io/skpr/node:16-v2-latest (Unsupported. Will not receive updates.)
 docker.io/skpr/node:18-v2-latest
 docker.io/skpr/node:20-v2-latest
 
@@ -28,8 +28,8 @@ docker.io/skpr/node:dev-20-v2-latest
 **Edge**
 
 ```
-docker.io/skpr/node:14-v2-edge (Depreciated. Will not receive updates.)
-docker.io/skpr/node:16-v2-edge (Depreciated. Will not receive updates.)
+docker.io/skpr/node:14-v2-edge (Unsupported. Will not receive updates.)
+docker.io/skpr/node:16-v2-edge (Unsupported. Will not receive updates.)
 docker.io/skpr/node:18-v2-edge
 docker.io/skpr/node:20-v2-edge
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ docker.io/skpr/node:14-v2-latest (Depreciated. Will not receive updates.)
 docker.io/skpr/node:16-v2-latest
 docker.io/skpr/node:18-v2-latest
 docker.io/skpr/node:20-v2-latest
+
 docker.io/skpr/node:dev-16-v2-latest
 docker.io/skpr/node:dev-18-v2-latest
 docker.io/skpr/node:dev-20-v2-latest
@@ -31,6 +32,7 @@ docker.io/skpr/node:14-v2-edge (Depreciated. Will not receive updates.)
 docker.io/skpr/node:16-v2-edge
 docker.io/skpr/node:18-v2-edge
 docker.io/skpr/node:20-v2-edge
+
 docker.io/skpr/node:dev-16-v2-edge
 docker.io/skpr/node:dev-18-v2-edge
 docker.io/skpr/node:dev-20-v2-edge

--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ docker.io/skpr/node:14-v2-edge (Depreciated. Will not receive updates.)
 docker.io/skpr/node:16-v2-edge
 docker.io/skpr/node:18-v2-edge
 docker.io/skpr/node:20-v2-edge
-docker.io/skpr/node:21-v2-edge
 docker.io/skpr/node:dev-16-v2-edge
 docker.io/skpr/node:dev-18-v2-edge
 docker.io/skpr/node:dev-20-v2-edge
-docker.io/skpr/node:dev-21-v2-edge
 ```


### PR DESCRIPTION
* Bump to Alpine 3.19
* Deprecate Node 16