### PR TITLE
chore: updates image tags from latest to stable and edge to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,10 +33,10 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_latest:
+  build_edge:
     jobs:
       - build:
-          stream: latest
+          stream: edge
           context: docker-publishing
           matrix:
             parameters:
@@ -46,7 +46,7 @@ workflows:
             branches:
               only: [ main ]
       - manifest:
-          stream: latest
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           matrix:
@@ -79,7 +79,7 @@ workflows:
             branches:
               only: [ releases ]
 
-  nightly_latest:
+  build_latest:
     jobs:
       - build:
           stream: latest
@@ -88,8 +88,31 @@ workflows:
             parameters:
               executor: *platforms
               node_version: *node_versions
+          filters:
+            branches:
+              only: [ releases ]
       - manifest:
           stream: latest
+          context: docker-publishing
+          requires: [ build ]
+          matrix:
+            parameters:
+              node_version: *node_versions
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_edge:
+    jobs:
+      - build:
+          stream: edge
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+              node_version: *node_versions
+      - manifest:
+          stream: edge
           context: docker-publishing
           requires: [ build ]
           matrix:
@@ -117,6 +140,33 @@ workflows:
               node_version: *node_versions
       - manifest:
           stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          matrix:
+            parameters:
+              node_version: *node_versions
+          filters:
+            branches:
+              only: [ releases ]
+    triggers:
+      - schedule:
+          # Scheduled build for 2am AEST nightly.
+          cron: "0 15 * * *"
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+              node_version: *node_versions
+      - manifest:
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,29 +33,6 @@ workflows:
             branches:
               ignore: [ main, releases ]
 
-  build_edge:
-    jobs:
-      - build:
-          stream: edge
-          context: docker-publishing
-          matrix:
-            parameters:
-              executor: *platforms
-              node_version: *node_versions
-          filters:
-            branches:
-              only: [ main ]
-      - manifest:
-          stream: edge
-          context: docker-publishing
-          requires: [ build ]
-          matrix:
-            parameters:
-              node_version: *node_versions
-          filters:
-            branches:
-              only: [ main ]
-
   build_latest:
     jobs:
       - build:
@@ -67,7 +44,7 @@ workflows:
               node_version: *node_versions
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
       - manifest:
           stream: latest
           context: docker-publishing
@@ -77,19 +54,42 @@ workflows:
               node_version: *node_versions
           filters:
             branches:
-              only: [ releases ]
+              only: [ main ]
 
-  nightly_edge:
+  build_stable:
     jobs:
       - build:
-          stream: edge
+          stream: stable
+          context: docker-publishing
+          matrix:
+            parameters:
+              executor: *platforms
+              node_version: *node_versions
+          filters:
+            branches:
+              only: [ releases ]
+      - manifest:
+          stream: stable
+          context: docker-publishing
+          requires: [ build ]
+          matrix:
+            parameters:
+              node_version: *node_versions
+          filters:
+            branches:
+              only: [ releases ]
+
+  nightly_latest:
+    jobs:
+      - build:
+          stream: latest
           context: docker-publishing
           matrix:
             parameters:
               executor: *platforms
               node_version: *node_versions
       - manifest:
-          stream: edge
+          stream: latest
           context: docker-publishing
           requires: [ build ]
           matrix:
@@ -106,17 +106,17 @@ workflows:
             branches:
               only: [ main ]
 
-  nightly_latest:
+  nightly_stable:
     jobs:
       - build:
-          stream: latest
+          stream: stable
           context: docker-publishing
           matrix:
             parameters:
               executor: *platforms
               node_version: *node_versions
       - manifest:
-          stream: latest
+          stream: stable
           context: docker-publishing
           requires: [ build ]
           matrix:


### PR DESCRIPTION
## Overview

Update Image tags from `edge` to `latest` and update `latest` to `stable`

## Implementation

I've updated the image tags and even stage names to reflect the change

## How to Test

Running the build pipeline will build the tags as intended

## What is the rollout plan?

We need to update skpr to use the new image tags and for those projects not on skpr update their pipelines. 

## Does this change need a blog post?

No

## Link to Tickets

* https://previousnext.atlassian.net/browse/SKPR-958 