### PR TITLE
Npm to PNPM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,6 +150,13 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Install: Container Structure Tests"
+          command: |
+            curl -LO https://storage.googleapis.com/container-structure-test/v1.11.0/container-structure-test-linux-<< parameters.executor >> && \
+            mv container-structure-test-linux-<< parameters.executor >> container-structure-test && \
+            chmod +x container-structure-test && \
+            sudo mv container-structure-test /usr/local/bin/
+      - run:
           name: Build, Test and Release
           command: |
             SHA1_VERSION="v3-$(git rev-parse --short HEAD)"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
 ARG FROM_IMAGE
 FROM ${FROM_IMAGE}
 
-# Install pnpm. Recommeded installation path.
-# See also:
-# - https://pnpm.io/docker
-RUN corepack enable && \
-    corepack prepare pnpm@10 --activate && \
-    echo "PNPM Version during build:" && \
-    pnpm --version
-
 # Libuv 1.45.0 is affected by a kernel bug on certain kernels.
 # This leads to errors where Garden tool downloading errors with ETXTBSY
 # Apparently file descriptor accounting is broken when using USE_IO_URING
@@ -50,6 +42,10 @@ RUN chmod +x /usr/local/bin/npm
 RUN mv /usr/local/bin/yarn /usr/local/bin/yarn-unsafe
 ADD --chown=skpr:skpr bin/yarn-wrapper /usr/local/bin/yarn
 RUN chmod +x /usr/local/bin/yarn
+
+# Install pnpm globally using the unsafe npm.
+# @todo, To be replaced with APK package when available (We want 10+).
+RUN npm-unsafe install -g pnpm@10
 
 USER skpr
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ build:
 	docker build --build-arg FROM_IMAGE=node:${NODE_VERSION}-alpine${ALPINE_VERSION} -t ${IMAGE}-${ARCH} .
 	# Building development image.
 	docker build --build-arg FROM_IMAGE=${IMAGE}-${ARCH} -t ${IMAGE_DEV}-${ARCH} dev
+	# Testing development image.
+	container-structure-test test --image ${IMAGE_DEV}-${ARCH} --config tests.yml
 
 push:
 	# Pushing production image.

--- a/tests.yml
+++ b/tests.yml
@@ -1,0 +1,20 @@
+schemaVersion: '2.0.0'
+
+commandTests:
+  - name:  "npm"
+    command: "npm"
+    args: ["--help"]
+    expectedOutput: ["DISCLAIMER"]
+    exitCode: 1
+
+  - name:  "yarn"
+    command: "yarn"
+    args: ["--help"]
+    expectedOutput: ["DISCLAIMER"]
+    exitCode: 0
+
+  - name:  "pnpm"
+    command: "pnpm"
+    args: ["--help"]
+    expectedOutput: ["compiled to binary"]
+    exitCode: 0


### PR DESCRIPTION
* Don't enable corepack
* Use npm-unsafe to download pnpm binary
* Adds container tests for validation