### PR TITLE
pnpm doesnt contain compiled message.

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: 🏗️ Build  Docker image
-        uses: docker/bake-action@v6\
+        uses: docker/bake-action@v6
         env:
           NODE_VERSION: ${{ matrix.node }}
           STREAM: ${{ env.stream }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache \
   curl \
   g++ \
   git \
+  jq \
   make \
   openssh-client \
   python3 \

--- a/tests.bats
+++ b/tests.bats
@@ -18,8 +18,8 @@ setup() {
   assert_output --partial "DISCLAIMER"
 }
 
-@test "pnpm --help exits 0 and mentions 'compiled to binary'" {
+@test "pnpm --help exits 0 and mentions 'Usage: pnpm [command] [flags]'" {
   run pnpm --help
   [ "$status" -eq 0 ]
-  assert_output --partial "compiled to binary"
+  assert_output --partial "Usage: pnpm [command] [flags]"
 }


### PR DESCRIPTION
`pnpm` does contain the compiled message any more. This should be enough to prove it's the pnpm binary and not a symlink to `npm`.