### PR TITLE
feat(core): add Node 26, drop Node 20, bump to Alpine 3.24

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,15 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '22', '24', '26' ]
-        alpine: [ '3.21', '3.24']
-        exclude:
+        include:
           - node: '22'
-            alpine: '3.24'
-          - node: '24'
-            alpine: '3.24'
-          - node: '26'
             alpine: '3.21'
+          - node: '24'
+            alpine: '3.21'
+          - node: '26'
+            alpine: '3.24'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -17,7 +17,7 @@ jobs:
           - node: '22'
             alpine: '3.21'
           - node: '24'
-            alpine: '3.21'
+            alpine: '3.24'
           - node: '26'
             alpine: '3.24'
 

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,13 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - node: '22'
-            alpine: '3.21'
-          - node: '24'
-            alpine: '3.24'
-          - node: '26'
-            alpine: '3.24'
+        node: [ '22', '24', '26' ]
 
     steps:
       - name: Checkout repository
@@ -32,7 +26,7 @@ jobs:
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
-          ALPINE_VERSION: ${{ matrix.alpine }}
+          ALPINE_VERSION: '3.24'
           STREAM: ${{ env.stream }}
         with:
           source: .

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,11 +13,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '20', '22', '24', '26' ]
+        node: [ '22', '24', '26' ]
         alpine: [ '3.21', '3.24']
         exclude:
-          - node: '20'
-            alpine: '3.24'
           - node: '22'
             alpine: '3.24'
           - node: '24'
@@ -27,13 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: 🐋 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🏗️ Build  Docker image
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
           ALPINE_VERSION: ${{ matrix.alpine }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -13,7 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '20', '22', '24' ]
+        node: [ '20', '22', '24', '26' ]
+        alpine: [ '3.21', '3.24']
+        exclude:
+          - node: '20'
+            alpine: '3.24'
+          - node: '22'
+            alpine: '3.24'
+          - node: '24'
+            alpine: '3.24'
+          - node: '26'
+            alpine: '3.21'
 
     steps:
       - name: Checkout repository
@@ -26,6 +36,7 @@ jobs:
         uses: docker/bake-action@v6
         env:
           NODE_VERSION: ${{ matrix.node }}
+          ALPINE_VERSION: ${{ matrix.alpine }}
           STREAM: ${{ env.stream }}
         with:
           source: .

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -28,7 +28,7 @@ jobs:
       - name: 🐋 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: 🏗️ Build  Docker image
+      - name: 🏗️ Build Docker image
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -26,7 +26,6 @@ jobs:
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
-          ALPINE_VERSION: '3.24'
           STREAM: ${{ env.stream }}
         with:
           source: .

--- a/.github/workflows/build-push-stable.yml
+++ b/.github/workflows/build-push-stable.yml
@@ -15,4 +15,6 @@ jobs:
       stream: stable
       push: true
       branch: releases
+      node_versions: '["22","24"]'
+      alpine_version: '3.21'
     secrets: inherit

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,7 @@ jobs:
           - node: '22'
             alpine: '3.21'
           - node: '24'
-            alpine: '3.21'
+            alpine: '3.24'
           - node: '26'
             alpine: '3.24'
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,7 +38,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '20', '22', '24' ]
+        node: [ '20', '22', '24', '26' ]
+        alpine: [ '3.21', '3.24']
+        exclude:
+          - node: '20'
+            alpine: '3.24'
+          - node: '22'
+            alpine: '3.24'
+          - node: '24'
+            alpine: '3.24'
+          - node: '26'
+            alpine: '3.21'
 
     steps:
       - name: 📥 Checkout repository
@@ -66,6 +76,7 @@ jobs:
         uses: docker/bake-action@v6
         env:
           NODE_VERSION: ${{ matrix.node }}
+          ALPINE_VERSION: ${{ matrix.alpine }}
           STREAM: ${{ inputs.stream }}
         with:
           source: .

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,15 +38,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '22', '24', '26' ]
-        alpine: [ '3.21', '3.24']
-        exclude:
+        include:
           - node: '22'
-            alpine: '3.24'
-          - node: '24'
-            alpine: '3.24'
-          - node: '26'
             alpine: '3.21'
+          - node: '24'
+            alpine: '3.21'
+          - node: '26'
+            alpine: '3.24'
 
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,6 +19,14 @@ on:
         type: string
         default: main
         description: Branch name to build from.
+      node_versions:
+        type: string
+        default: '["22","24","26"]'
+        description: JSON array of Node.js versions to build.
+      alpine_version:
+        type: string
+        default: '3.24'
+        description: Alpine Linux version to build against.
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -38,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '22', '24', '26' ]
+        node: ${{ fromJson(inputs.node_versions) }}
 
     steps:
       - name: 📥 Checkout repository
@@ -66,6 +74,7 @@ jobs:
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
+          ALPINE_VERSION: ${{ inputs.alpine_version }}
           STREAM: ${{ inputs.stream }}
         with:
           source: .

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -66,7 +66,6 @@ jobs:
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
-          ALPINE_VERSION: '3.24'
           STREAM: ${{ inputs.stream }}
         with:
           source: .

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,13 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - node: '22'
-            alpine: '3.21'
-          - node: '24'
-            alpine: '3.24'
-          - node: '26'
-            alpine: '3.24'
+        node: [ '22', '24', '26' ]
 
     steps:
       - name: 📥 Checkout repository
@@ -72,7 +66,7 @@ jobs:
         uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
-          ALPINE_VERSION: ${{ matrix.alpine }}
+          ALPINE_VERSION: '3.24'
           STREAM: ${{ inputs.stream }}
         with:
           source: .

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,11 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [ '20', '22', '24', '26' ]
+        node: [ '22', '24', '26' ]
         alpine: [ '3.21', '3.24']
         exclude:
-          - node: '20'
-            alpine: '3.24'
           - node: '22'
             alpine: '3.24'
           - node: '24'
@@ -52,28 +50,28 @@ jobs:
 
     steps:
       - name: 📥 Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch }}
 
       - name: 🔑 Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: 🔑 Log in to the GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 🐋 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🏗️ Build and push Docker image
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           NODE_VERSION: ${{ matrix.node }}
           ALPINE_VERSION: ${{ matrix.alpine }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: 🔑 Log in to the GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,6 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         image_ref:
+          - ghcr.io/skpr/node:26-v3-latest
+          - ghcr.io/skpr/node:dev-26-v3-latest
           - ghcr.io/skpr/node:24-v3-latest
           - ghcr.io/skpr/node:dev-24-v3-latest
           - ghcr.io/skpr/node:22-v3-latest

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,8 +24,6 @@ jobs:
           - ghcr.io/skpr/node:dev-24-v3-latest
           - ghcr.io/skpr/node:22-v3-latest
           - ghcr.io/skpr/node:dev-22-v3-latest
-          - ghcr.io/skpr/node:20-v3-latest
-          - ghcr.io/skpr/node:dev-20-v3-latest
 
     steps:
       - name: 🔑 Log in to the GitHub Container Registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir /data && chown skpr:skpr /data
 WORKDIR /data
 
 # Replace npm with a wrapper script to enforce security.
-RUN npm install -g yarn
+RUN npm install -g yarn --force
 RUN mv /usr/local/bin/npm /usr/local/bin/npm-unsafe
 ADD --chown=skpr:skpr bin/npm-wrapper /usr/local/bin/npm
 RUN chmod +x /usr/local/bin/npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,10 @@ RUN mkdir /data && chown skpr:skpr /data
 
 WORKDIR /data
 
+# Ensure yarn is available before wrapping (Node 26+ no longer ships yarn).
+RUN npm install -g yarn
+
 # Replace npm with a wrapper script to enforce security.
-RUN npm install -g yarn --force
 RUN mv /usr/local/bin/npm /usr/local/bin/npm-unsafe
 ADD --chown=skpr:skpr bin/npm-wrapper /usr/local/bin/npm
 RUN chmod +x /usr/local/bin/npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir /data && chown skpr:skpr /data
 WORKDIR /data
 
 # Ensure yarn is available before wrapping (Node 26+ no longer ships yarn).
-RUN npm install -g yarn
+RUN npm install -g yarn --force
 
 # Replace npm with a wrapper script to enforce security.
 RUN mv /usr/local/bin/npm /usr/local/bin/npm-unsafe

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN mkdir /data && chown skpr:skpr /data
 WORKDIR /data
 
 # Replace npm with a wrapper script to enforce security.
+RUN npm install -g yarn
 RUN mv /usr/local/bin/npm /usr/local/bin/npm-unsafe
 ADD --chown=skpr:skpr bin/npm-wrapper /usr/local/bin/npm
 RUN chmod +x /usr/local/bin/npm

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,7 +3,7 @@ variable "NODE_VERSION" {
 }
 
 variable "ALPINE_VERSION" {
-  default = "3.21"
+  default = "3.24"
 }
 
 variable "STREAM" {


### PR DESCRIPTION
Adds Node 26 support, drops EOL Node 20, and aligns Alpine versions across streams.

- Install yarn explicitly before wrapping, as Node 26+ no longer ships it in the base image
- Latest builds: Node 22, 24, 26 on Alpine 3.24
- Stable builds: Node 22, 24 on Alpine 3.21 (Node 26 excluded until stable moves to 3.24)
- Bump Alpine default from 3.21 to 3.24 in `docker-bake.hcl`
- Add `node_versions` and `alpine_version` inputs to `build-push.yml` to allow per-stream configuration
- Replace Node 20 with Node 26 in the security scan matrix
- Bump all GitHub Actions to latest majors (checkout@v7, login-action@v4, setup-buildx-action@v4, bake-action@v7)